### PR TITLE
remove bundle inheritance

### DIFF
--- a/src/Resources/skeleton/bundle/bundle.mustache
+++ b/src/Resources/skeleton/bundle/bundle.mustache
@@ -14,11 +14,4 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class {{ application }}{{ bundle }} extends Bundle
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getParent()
-    {
-        return '{{ bundle }}';
-    }
 }


### PR DESCRIPTION
Symfony 3.4 dropped bundle inheritance, the created bundles should not need it

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataEasyExtendsBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it is probably not backwards compatible?

if otherwise, i will rebase it

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #152

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- removed Bundle inheritance

```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

## Subject

<!-- Describe your Pull Request content here -->
